### PR TITLE
Add next/babel presets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,14 @@
 {
-  "plugins": [["styled-jsx/babel", { "plugins": ["styled-jsx-plugin-sass"] }]]
+  "presets": [
+    [
+      "next/babel",
+      {
+        "styled-jsx": {
+          "plugins": [
+            "styled-jsx-plugin-sass"
+          ]
+        }
+      }
+    ]
+  ]
 }


### PR DESCRIPTION
Hello, with a custom .babel file in nextjs, we need to add a next/babel presets, no ? (like https://github.com/zeit/next.js/blob/canary/examples/with-styled-jsx-scss/.babelrc)
Otherwise, it shows an error.